### PR TITLE
Added cloud watch substrate configs for dev and prod

### DIFF
--- a/cloudwatch/README.md
+++ b/cloudwatch/README.md
@@ -1,0 +1,15 @@
+#How to apply Cloudwatch Configs Using EC2 RunCommand
+
+###Cloudwatch Configuration Documentation
+* [Cloudwatch Logs] (http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html?shortFooter=true)
+* [AWS:Cloudwatch] (http://docs.aws.amazon.com/ssm/latest/APIReference/aws-cloudWatch.html)
+* [Cloudwatch Configuration Using EC2 RunCommand] (http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/remote-commands-cloudwatch.html)
+
+###Steps to Upload Configuration to EC2 Instance
+1. Log into AWS and select the EC2 Service
+2. Select **Run Command** from the **SYSTEMS MANAGER SERVICES** menu
+3. Click **Run a Command** button located at the top of the page
+4. In the **Command document** select **AWS-ConfigureCloudWatch**
+5. Select **Target Instance** 
+6. Copy and Paste the json config file into the **Properties** text field
+7. Click **Run** found at the bottom right of the webpage

--- a/cloudwatch/dev-substrate-config.json
+++ b/cloudwatch/dev-substrate-config.json
@@ -1,0 +1,74 @@
+{
+	"EngineConfiguration": {
+		"PollInterval": "00:00:15",
+		"Components": [{
+			"Id": "ApplicationEventLog",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "Application",
+				"Levels": "4"
+			}
+		}, {
+			"Id": "SystemEventLog",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "System",
+				"Levels": "7"
+			}
+		}, {
+			"Id": "SecurityEventLog",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "Security",
+				"Levels": "7"
+			}
+		}, {
+			"Id": "ETW",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "Microsoft-Windows-WinINet/Analytic",
+				"Levels": "7"
+			}
+		}, {
+			"Id": "PerformanceCounter",
+			"FullName": "AWS.EC2.Windows.CloudWatch.PerformanceCounterComponent.PerformanceCounterInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"CategoryName": "Memory",
+				"CounterName": "Available MBytes",
+				"InstanceName": "name",
+				"MetricName": "AvailableMemory",
+				"Unit": "Megabytes",
+				"DimensionName": "",
+				"DimensionValue": ""
+			}
+		}, {
+			"Id": "CloudWatchLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"LogGroup": "dev-substrate-web",
+				"LogStream": "{instance_id}"
+			}
+		}, {
+			"Id": "CloudWatch",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatch.CloudWatchOutputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"NameSpace": "Windows/Default"
+			}
+		}],
+		"Flows": {
+			"Flows": [
+				"ApplicationEventLog,CloudWatchLogs",
+				"SystemEventLog,CloudWatchLogs",
+				"SecurityEventLog, CloudWatchLogs",
+				"ETW, CloudWatchLogs",
+				"PerformanceCounter, CloudWatch"
+			]
+		}
+	}
+}

--- a/cloudwatch/prod-substrate-config.json
+++ b/cloudwatch/prod-substrate-config.json
@@ -1,0 +1,121 @@
+{
+	"EngineConfiguration": {
+		"PollInterval": "00:00:15",
+		"Components": [
+		{
+			"Id": "ApplicationEventLog",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "Application",
+				"Levels": "4"
+			}
+		}, {
+			"Id": "SystemEventLog",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "System",
+				"Levels": "4"
+			}
+		}, {
+			"Id": "SecurityEventLog",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "Security",
+				"Levels": "4"
+			}
+		}, {
+			"Id": "ETW",
+			"FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogName": "Microsoft-Windows-WinINet/Analytic",
+				"Levels": "4"
+			}
+		},
+		{
+			"Id": "CustomLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CustomLog.CustomLogInputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"LogDirectoryPath": "C:\\inetpub\\logs\\",
+				"TimestampFormat": "yyyy-MM-dd HH:mm:ss,fff",
+				"Encoding": "UTF-8",
+				"Filter": "",
+				"CultureName": "en-US",
+				"TimeZoneKind": "Local",
+				"LineCount": "1"
+			}
+		}, {
+			"Id": "SubstrateCloudWatchLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"LogGroup": "prod-substrate-web",
+				"LogStream": "{instance_id}/substrate.log"
+			}
+		}, 
+		{
+			"Id": "AppCloudWatchLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"LogGroup": "prod-substrate-web",
+				"LogStream": "{instance_id}/application"
+			}
+		},
+		{
+			"Id": "SysCloudWatchLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"LogGroup": "prod-substrate-web",
+				"LogStream": "{instance_id}/system"
+			}
+		},
+		{
+			"Id": "SecCloudWatchLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"LogGroup": "prod-substrate-web",
+				"LogStream": "{instance_id}/security"
+			}
+		},
+		{
+			"Id": "ETWCloudWatchLogs",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"LogGroup": "prod-substrate-web",
+				"LogStream": "{instance_id}/etw"
+			}
+		},
+		{
+			"Id": "CloudWatch",
+			"FullName": "AWS.EC2.Windows.CloudWatch.CloudWatch.CloudWatchOutputComponent,AWS.EC2.Windows.CloudWatch",
+			"Parameters": {
+				"AccessKey": "",
+				"SecretKey": "",
+				"Region": "us-east-1",
+				"NameSpace": "Windows/Default"
+			}
+		}],
+		"Flows": {
+			"Flows": [
+				"ApplicationEventLog, AppCloudWatchLogs",
+				"SystemEventLog, SysCloudWatchLogs",
+				"SecurityEventLog, SecCloudWatchLogs",
+				"ETW, ETWCloudWatchLogs",
+				"CustomLogs, SubstrateCloudWatchLogs"
+			]
+		}
+	}
+}


### PR DESCRIPTION
## :runner: [Trello Sprint Cards](https://wiki.moxehealth.com/Development/Pull_Request_Process#Trello_Sprint_Cards)
[Taco Trello](https://trello.com/c/MVcVXZw8/456-m-track-application-logs-with-cloudwatch)

## :memo: [Description](https://wiki.moxehealth.com/Development/Pull_Request_Process#Description) 
_Add cloudwatch configuration to dev and prod environments._

## :link: [Design Documents](https://wiki.moxehealth.com/Development/Pull_Request_Process#Design_Documents)

## :vertical_traffic_light: [Testing Notes](https://wiki.moxehealth.com/Development/Pull_Request_Process#Testing_Notes)
_View cloudwatch logs in AWS. Log Groups are **dev-substrate-web** and **prod-substrate-web**_

## :mega: [Deployment Notes](https://wiki.moxehealth.com/Development/Pull_Request_Process#Deployment_Notes)
### :bangbang: [DB Schema Changes](https://wiki.moxehealth.com/Development/Pull_Request_Process#DB_Schema_or_Data_Migration_Changes)
**No** | Yes
_If yes, which tables and columns_


### :interrobang: [Deployment Checklist](https://wiki.moxehealth.com/Development/Pull_Request_Process#Deployment_Notes)
- [Db Seeding or data script migration?](https://wiki.moxehealth.com/Development/Pull_Request_Process#DB_Seeding)
- [web.config updates?](https://wiki.moxehealth.com/Development/Pull_Request_Process#web.config_Updates)
- [DynamoDb Tables?](https://wiki.moxehealth.com/Development/Pull_Request_Process#New_DynamoDb_Tables)
- Other? ¯\\\_(ツ)\_/¯


## :package: Related PRs
_To relate PRs type the '#' sign and the number of the PR_